### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/gjersvik/dartup.png?label=ready&title=Ready)](https://waffle.io/gjersvik/dartup)
 # dartup
 [![Build Status](https://travis-ci.org/gjersvik/dartup.svg?branch=master)](https://travis-ci.org/gjersvik/dartup)
 [![Coverage Status](https://coveralls.io/repos/gjersvik/dartup/badge.svg)](https://coveralls.io/r/gjersvik/dartup)


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/gjersvik/dartup

This was requested by a real person (user gjersvik) on waffle.io, we're not trying to spam you.
